### PR TITLE
Label loading

### DIFF
--- a/src/napari_ome_zarr_roi_loader/roi_loader_widget.py
+++ b/src/napari_ome_zarr_roi_loader/roi_loader_widget.py
@@ -74,6 +74,7 @@ class RoiLoader(Container):
             )
             return
         blending = None
+        scale_img = None
         for channel in channels:
             img_roi, scale_img = load_intensity_roi(
                 zarr_url=self._zarr_url_picker.value,
@@ -104,7 +105,7 @@ class RoiLoader(Container):
                 zarr_url=self._zarr_url_picker.value,
                 roi_of_interest=roi_name,
                 label_name=label,
-                level=0,  # FIXME: Allow loading of labels at different levels?
+                target_scale=scale_img,
                 roi_table=roi_table,
             )
             self._viewer.add_labels(label_roi, scale=scale_label)

--- a/src/napari_ome_zarr_roi_loader/roi_loader_widget.py
+++ b/src/napari_ome_zarr_roi_loader/roi_loader_widget.py
@@ -5,6 +5,7 @@ Written by:
 Joel Luethi, joel.luethi@fmi.ch
 """
 import os
+from pathlib import Path
 
 import napari
 import zarr
@@ -13,6 +14,7 @@ from napari.utils.notifications import show_info
 
 from napari_ome_zarr_roi_loader.utils import (
     get_channel_dict,
+    get_label_dict,
     get_metadata,
     load_intensity_roi,
     read_roi_table,
@@ -24,6 +26,7 @@ class RoiLoader(Container):
         self._viewer = viewer
         self.channel_dict = {}
         self.channel_names_dict = {}
+        self.labels_dict = {}
         self._zarr_url_picker = FileEdit(label="Zarr URL", mode="d")
         self._roi_table_picker = ComboBox(label="ROI Table")
         self._roi_picker = ComboBox(label="ROI")
@@ -31,6 +34,9 @@ class RoiLoader(Container):
             label="Channels",
         )
         self._level_picker = ComboBox(label="Level")
+        self._label_picker = Select(
+            label="Labels",
+        )
         self._run_button = PushButton(value=False, text="Load ROI")
 
         # Initialize possible choices
@@ -49,6 +55,7 @@ class RoiLoader(Container):
                 self._roi_picker,
                 self._channel_picker,
                 self._level_picker,
+                self._label_picker,
                 self._run_button,
             ]
         )
@@ -88,16 +95,6 @@ class RoiLoader(Container):
             )
             blending = "additive"
 
-        # FIXME: For some reason, running currently resets the
-        # self._roi_table_picker choices to an empty list. This works around
-        # that. No idea why this reset is happening though. See
-        # https://github.com/jluethi/napari-ome-zarr-roi-loader/issues/3
-        # self.update_roi_tables()
-        # self._roi_table_picker.value = roi_table
-        # self._roi_picker.value = roi_name
-        # self._level_picker.value = level
-        # self._channel_picker.value = channels
-
     def update_roi_tables(self):
         """
         Handles updating the list of available ROI tables
@@ -120,6 +117,11 @@ class RoiLoader(Container):
         levels = self._get_level_choices()
         self._level_picker.choices = levels
         self._level_picker._default_choices = levels
+
+        # Initialize available label images
+        labels = self._get_label_choices()
+        self._label_picker.choices = labels
+        self._label_picker._default_choices = labels
 
     def _get_roi_table_choices(self):
         try:
@@ -165,6 +167,17 @@ class RoiLoader(Container):
             channel_name = self.channel_dict[channel_index]["label"]
             self.channel_names_dict[channel_name] = channel_index
         return list(self.channel_names_dict.keys())
+
+    def _get_label_choices(self):
+        self.label_dict = get_label_dict(
+            Path(self._zarr_url_picker.value) / "labels"
+        )
+        return list(self.label_dict.values())
+        # self.labels_names_dict = {}
+        # for label_index in self.label_dict.keys():
+        #     label_name = self.label_dict[label_index]
+        #     self.labels_names_dict[label_name] = label_index
+        # return list(self.labels_names_dict.keys())
 
     def _get_level_choices(self):
         try:

--- a/src/napari_ome_zarr_roi_loader/utils.py
+++ b/src/napari_ome_zarr_roi_loader/utils.py
@@ -202,8 +202,6 @@ def load_intensity_roi(
     img_data_zyx = da.from_zarr(f"{zarr_url}/{level}")[channel_index]
     img_roi = img_data_zyx[s_z:e_z, s_y:e_y, s_x:e_x]
 
-    # TODO: Load the rescaling parameters & also return those
-
     return np.array(img_roi), scale_img
 
 
@@ -211,25 +209,23 @@ def load_label_roi(
     zarr_url,
     roi_of_interest,
     label_name,
-    level=0,
+    target_scale=None,
     roi_table="FOV_ROI_table",
 ):
     # Loads the label image of a given ROI in a well
     # returns the image as a numpy array + a list of the image scale
 
-    # image_index defaults to 0 (Change if you have more than one
-    # image per well) => FIXME for multiplexing
-
     # Get the ROI table
     roi_an = read_roi_table(zarr_url, roi_table)
 
     # Load the pixel sizes from the OME-Zarr file
-    dataset = 0  # FIXME, hard coded in case multiple multiscale
-    # datasets would be present & multiscales is a list
-    metadata = get_metadata(zarr_url / "labels" / label_name)
-    scale_lbls = metadata.attrs["multiscales"][dataset]["datasets"][level][
-        "coordinateTransformations"
-    ][0]["scale"]
+    scales = get_available_scales(zarr_url / "labels" / label_name)
+    if target_scale:
+        level = get_closest_scale(target_scale, scales)
+        scale_lbls = scales[level]
+    else:
+        level = "0"
+        scale_lbls = scales[level]
 
     # Get ROI indices for labels
     indices_dict = convert_ROI_table_to_indices(
@@ -243,9 +239,45 @@ def load_label_roi(
     s_z, e_z, s_y, e_y, s_x, e_x = indices[:]
 
     # Load data
-    lbl_data_zyx = da.from_zarr(zarr_url / "labels" / label_name / str(level))
+    lbl_data_zyx = da.from_zarr(zarr_url / "labels" / label_name / level)
     lbl_roi = lbl_data_zyx[s_z:e_z, s_y:e_y, s_x:e_x]
 
-    # TODO: Load the rescaling parameters & also return those
-
     return np.array(lbl_roi), scale_lbls
+
+
+def get_available_scales(zarr_url):
+    metadata = get_metadata(zarr_url)
+    dataset = 0  # FIXME, hard coded in case multiple multiscale
+    # datasets would be present & multiscales is a list
+    available_scales = {}
+    levels = metadata.attrs["multiscales"][dataset]["datasets"]
+    for level in levels:
+        for transformation in level["coordinateTransformations"]:
+            if transformation["type"] == "scale":
+                available_scales[level["path"]] = transformation["scale"]
+            else:
+                pass
+                # Ignore other transformations
+    return available_scales
+
+
+def get_closest_scale(target_scale, scales):
+    """
+    Should mostly provide either the highest resolution or the one exactly
+    matching the target scale, given that label images are usually downsampled.
+    But would need to generalize to handle arbitrary target_scales better.
+
+    params: target_scale: list of floats
+            scales: dict of scales. Keys are the names of the folders in the
+                    OME-Zarr, values are the scales (list of floats)
+    """
+    closest_scale = list(scales.keys())[0]
+    for key, val in scales.items():
+        if np.linalg.norm(
+            np.array(val) - np.array(target_scale)
+        ) < np.linalg.norm(
+            np.array(scales[closest_scale]) - np.array(target_scale)
+        ):
+            closest_scale = key
+
+    return closest_scale

--- a/src/napari_ome_zarr_roi_loader/utils.py
+++ b/src/napari_ome_zarr_roi_loader/utils.py
@@ -144,6 +144,25 @@ def get_channel_dict(zarr_url):
     return channel_dict
 
 
+def get_label_dict(label_zarr_url):
+    # Based on the label_zarr_url, load the available labels
+    # params: label_zarr_url: Path to the label folder in the OME-Zarr file
+
+    # Check that the label folder exists
+    if not label_zarr_url.exists():
+        return {}
+
+    metadata = get_metadata(label_zarr_url)
+    label_dict = {}
+    try:
+        for i, label in enumerate(metadata.attrs["labels"]):
+            label_dict[i] = label
+    except KeyError:
+        pass
+
+    return label_dict
+
+
 def load_intensity_roi(
     zarr_url,
     roi_of_interest,


### PR DESCRIPTION
Closes #4 

Label images are always loaded at their full resolution for the time being.
Reason: label images can be lower resolution than the intensity image. So we don't want to pick just the same pyramid level. A fancier version could be loading label images at the resolution closest to the intensity image, but that would add some complexity.